### PR TITLE
fix(arize): stop O(L²) trace emit in Anthropic / Claude Code path (ENG2-1036)

### DIFF
--- a/.github/workflows/build-oauth-fix-multiarch.yml
+++ b/.github/workflows/build-oauth-fix-multiarch.yml
@@ -12,6 +12,10 @@ on:
         description: "Push to Docker Hub registry"
         type: boolean
         default: true
+      platforms:
+        description: "Comma-separated platform list (linux/amd64, linux/arm64, or both)"
+        required: false
+        default: "linux/amd64,linux/arm64"
 
   # Auto-build on main branch changes
   push:
@@ -108,7 +112,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ github.event.inputs.platforms || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-oauth-fix-multiarch.yml
+++ b/.github/workflows/build-oauth-fix-multiarch.yml
@@ -79,8 +79,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            # Manual dispatch tag
-            type=raw,value=${{ github.event.inputs.tag }},enable={{is_default_branch}}
+            # Manual dispatch tag (also allow when dispatching from feature branches)
+            type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
             
             # Latest tag for main branch
             type=raw,value=latest,enable={{is_default_branch}}

--- a/litellm/integrations/arize/_utils.py
+++ b/litellm/integrations/arize/_utils.py
@@ -197,8 +197,15 @@ def handle_anthropic_claude_code_tracing(
 
     span_definitions: List[Tuple[str, Dict[str, Any], str]] = []
 
+    # ENG2-1036: emit child spans only for the latest turn, not the full history.
+    # Each of the three loops below previously walked all of `messages` from i=0,
+    # producing O(L) child spans per call and O(L²) child spans per session.
+    # Starting from the tail caps each loop at one or two iterations, keeping the
+    # latest-turn detail Phoenix users want without re-emitting prior history.
+    start_idx = max(0, len(messages) - 2)
+
     # Build internal prompt span data
-    i = 0
+    i = start_idx
     span_index = 0
     while i < len(messages):
         role = messages[i].get("role", "")
@@ -228,7 +235,7 @@ def handle_anthropic_claude_code_tracing(
         span_index += 1
 
     # Build internal tool span data
-    i = 0
+    i = start_idx
     span_index = 0
     while i < len(messages):
         role = messages[i].get("role", "")
@@ -254,7 +261,7 @@ def handle_anthropic_claude_code_tracing(
         span_index += 1
 
     # Build individual tool span data
-    i = 0
+    i = start_idx
     while i < len(messages):
         role = messages[i].get("role", "")
         content = messages[i].get("content", "")
@@ -439,19 +446,22 @@ def set_attributes(span: Span, kwargs, response_obj):  # noqa: PLR0915
                 last_message.get("content", ""),
             )
 
-            # LLM_INPUT_MESSAGES shows up under `input_messages` tab on the span page.
-            for idx, msg in enumerate(messages):
-                prefix = f"{SpanAttributes.LLM_INPUT_MESSAGES}.{idx}"
-                # Set the role per message.
-                safe_set_attribute(
-                    span, f"{prefix}.{MessageAttributes.MESSAGE_ROLE}", msg.get("role")
-                )
-                # Set the content per message.
-                safe_set_attribute(
-                    span,
-                    f"{prefix}.{MessageAttributes.MESSAGE_CONTENT}",
-                    msg.get("content", ""),
-                )
+            # ENG2-1036: emit only the LAST message as an llm.input_messages.* attribute.
+            # Previously we attached all N prior messages on every span, producing O(L²)
+            # bytes per session. The most recent turn is sufficient for span-page detail;
+            # full history reconstruction belongs in DAL post-ingest, not on every span.
+            last_idx = len(messages) - 1
+            prefix = f"{SpanAttributes.LLM_INPUT_MESSAGES}.{last_idx}"
+            safe_set_attribute(
+                span,
+                f"{prefix}.{MessageAttributes.MESSAGE_ROLE}",
+                last_message.get("role"),
+            )
+            safe_set_attribute(
+                span,
+                f"{prefix}.{MessageAttributes.MESSAGE_CONTENT}",
+                last_message.get("content", ""),
+            )
 
         # Capture tools (function definitions) used in the LLM call.
         tools = optional_params.get("tools")

--- a/scripts/measure_l2_baseline.after.txt
+++ b/scripts/measure_l2_baseline.after.txt
@@ -1,0 +1,23 @@
+warning: No `requires-python` value found in the workspace. Defaulting to `>=3.14`.
+ENG2-1036 — L² baseline measurement
+
+   L |  parent |   child |  in_msg_attrs |  child/L |  child/L²
+------------------------------------------------------------------
+   1 |       1 |       5 |             2 |     5.00 |      5.00
+   5 |       5 |      25 |            10 |     5.00 |      1.00
+  10 |      10 |      50 |            20 |     5.00 |      0.50
+  20 |      20 |     100 |            40 |     5.00 |      0.25
+  30 |      30 |     150 |            60 |     5.00 |      0.17
+
+Child span breakdown for L=30 (last row):
+  Claude_Code_Internal_Prompt                 60
+  Claude_Code_Final_Output                    30
+  Claude_Code_Tool                            30
+  Claude_Code_Internal_Tool                   30
+
+Interpretation:
+  - If child/L grows with L  → super-linear (the L² problem).
+  - If child/L² is roughly constant → confirmed quadratic.
+  - in_msg_attrs growing as L*(L+1)/2 confirms Source #1 (set_attributes parent-attr bloat).
+  - child_spans growing as ~L² confirms Source #2 (handle_anthropic_claude_code_tracing per-call child-span emit).
+

--- a/scripts/measure_l2_baseline.before.txt
+++ b/scripts/measure_l2_baseline.before.txt
@@ -1,0 +1,23 @@
+warning: No `requires-python` value found in the workspace. Defaulting to `>=3.14`.
+ENG2-1036 — L² baseline measurement
+
+   L |  parent |   child |  in_msg_attrs |  child/L |  child/L²
+------------------------------------------------------------------
+   1 |       1 |       5 |             6 |     5.00 |      5.00
+   5 |       5 |      55 |            70 |    11.00 |      2.20
+  10 |      10 |     185 |           240 |    18.50 |      1.85
+  20 |      20 |     670 |           880 |    33.50 |      1.68
+  30 |      30 |    1455 |          1920 |    48.50 |      1.62
+
+Child span breakdown for L=30 (last row):
+  Claude_Code_Internal_Prompt                495
+  Claude_Code_Tool                           465
+  Claude_Code_Internal_Tool                  465
+  Claude_Code_Final_Output                    30
+
+Interpretation:
+  - If child/L grows with L  → super-linear (the L² problem).
+  - If child/L² is roughly constant → confirmed quadratic.
+  - in_msg_attrs growing as L*(L+1)/2 confirms Source #1 (set_attributes parent-attr bloat).
+  - child_spans growing as ~L² confirms Source #2 (handle_anthropic_claude_code_tracing per-call child-span emit).
+

--- a/scripts/measure_l2_baseline.py
+++ b/scripts/measure_l2_baseline.py
@@ -1,0 +1,220 @@
+"""
+ENG2-1036 — measure O(L²) trace emit growth in the Arize integration.
+
+Simulates a Claude Code session of length L by calling
+`litellm.integrations.arize._utils.set_attributes` L times with progressively
+longer message histories. Captures every emitted span/attribute via an
+in-memory exporter and reports cumulative counts per session length.
+
+Usage:
+    uv run python scripts/measure_l2_baseline.py
+    # or:
+    python scripts/measure_l2_baseline.py
+
+Reports:
+    - parent span count          (should be == L)
+    - input_messages.* attrs     (sum should be L*(L+1)/2  →  O(L²))
+    - child span count           (sum should be ~ L*L      →  O(L²))
+    - child/L and child/L² ratios (the latter should be ~constant if O(L²))
+
+Re-run after the dedup patch and compare. Same scenario, same numbers post-fix
+should be O(L) instead of O(L²).
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any, Dict, List
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import (
+    SimpleSpanProcessor,
+    SpanExporter,
+    SpanExportResult,
+)
+
+from litellm.integrations.arize import _utils
+
+
+class ListExporter(SpanExporter):
+    """Captures every finished span in memory for inspection."""
+
+    def __init__(self) -> None:
+        self.spans: List[Any] = []
+
+    def export(self, spans):
+        self.spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:
+        pass
+
+    def clear(self) -> None:
+        self.spans = []
+
+
+_EXPORTER = ListExporter()
+_PROVIDER = TracerProvider()
+_PROVIDER.add_span_processor(SimpleSpanProcessor(_EXPORTER))
+trace.set_tracer_provider(_PROVIDER)
+_TRACER = trace.get_tracer("litellm")
+
+
+def build_messages(num_pairs: int) -> List[Dict[str, Any]]:
+    """Build a Claude Code-style messages array.
+
+    Each pair is one user turn + one assistant turn that calls a tool.
+    The final turn is a user `tool_result`, mirroring how Claude Code calls
+    Anthropic mid-conversation.
+    """
+    msgs: List[Dict[str, Any]] = []
+    for i in range(num_pairs):
+        msgs.append({"role": "user", "content": f"please run command number {i}"})
+        msgs.append(
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": f"toolu_{i:04d}",
+                        "name": "Bash",
+                        "input": {"command": f"echo {i}"},
+                    }
+                ],
+            }
+        )
+    if num_pairs > 0:
+        msgs.append(
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": f"toolu_{num_pairs - 1:04d}",
+                        "content": f"output of command {num_pairs - 1}",
+                    }
+                ],
+            }
+        )
+    return msgs
+
+
+def build_kwargs(messages: List[Dict[str, Any]]) -> Dict[str, Any]:
+    return {
+        "messages": messages,
+        "model": "claude-sonnet-4",
+        "optional_params": {"max_tokens": 4096},
+        "litellm_params": {"custom_llm_provider": "anthropic"},
+        "standard_logging_object": {
+            "call_type": "anthropic_messages",
+            "metadata": {"session_id": "l2-baseline-test"},
+            "model_parameters": {},
+        },
+    }
+
+
+def build_response(call_idx: int) -> Dict[str, Any]:
+    return {
+        "id": f"resp_{call_idx:04d}",
+        "model": "claude-sonnet-4",
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": f"response for call {call_idx}",
+                }
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 100 + call_idx * 50,
+            "completion_tokens": 20,
+            "total_tokens": 120 + call_idx * 50,
+        },
+    }
+
+
+def simulate_session(num_calls: int) -> Dict[str, int]:
+    """Simulate `num_calls` LLM calls.
+
+    Call K (1-indexed) sees K conversation pairs in its messages array,
+    matching how a real Claude Code session grows turn over turn.
+    """
+    _EXPORTER.clear()
+
+    for k in range(1, num_calls + 1):
+        messages = build_messages(num_pairs=k)
+        kwargs = build_kwargs(messages)
+        response = build_response(k)
+
+        with _TRACER.start_as_current_span(f"llm_call_{k:04d}") as parent_span:
+            _utils.set_attributes(parent_span, kwargs, response)
+
+    spans = list(_EXPORTER.spans)
+
+    parent_spans = [s for s in spans if s.name.startswith("llm_call_")]
+    child_spans = [s for s in spans if not s.name.startswith("llm_call_")]
+
+    input_msg_attrs = 0
+    for s in parent_spans:
+        for key in s.attributes.keys():
+            if key.startswith("llm.input_messages."):
+                input_msg_attrs += 1
+
+    by_kind: Dict[str, int] = {}
+    for s in child_spans:
+        prefix = s.name.rsplit("_", 1)[0] if "_" in s.name else s.name
+        by_kind[prefix] = by_kind.get(prefix, 0) + 1
+
+    return {
+        "L": num_calls,
+        "parent_spans": len(parent_spans),
+        "child_spans": len(child_spans),
+        "input_msg_attrs": input_msg_attrs,
+        "by_kind": by_kind,
+    }
+
+
+def fmt_ratio(num: int, denom: int) -> str:
+    if denom == 0:
+        return "—"
+    return f"{num / denom:>6.2f}"
+
+
+def main() -> int:
+    print("ENG2-1036 — L² baseline measurement\n")
+    print(
+        f"{'L':>4} | {'parent':>7} | {'child':>7} | {'in_msg_attrs':>13} "
+        f"| {'child/L':>8} | {'child/L²':>9}"
+    )
+    print("-" * 66)
+
+    rows = []
+    for L in [1, 5, 10, 20, 30]:
+        r = simulate_session(L)
+        rows.append(r)
+        print(
+            f"{r['L']:>4} | {r['parent_spans']:>7} | {r['child_spans']:>7} "
+            f"| {r['input_msg_attrs']:>13} | {fmt_ratio(r['child_spans'], L):>8} "
+            f"| {fmt_ratio(r['child_spans'], L * L):>9}"
+        )
+
+    print("\nChild span breakdown for L=30 (last row):")
+    for kind, count in sorted(rows[-1]["by_kind"].items(), key=lambda x: -x[1]):
+        print(f"  {kind:<40} {count:>5}")
+
+    print(
+        "\nInterpretation:\n"
+        "  - If child/L grows with L  → super-linear (the L² problem).\n"
+        "  - If child/L² is roughly constant → confirmed quadratic.\n"
+        "  - in_msg_attrs growing as L*(L+1)/2 confirms Source #1 "
+        "(set_attributes parent-attr bloat).\n"
+        "  - child_spans growing as ~L² confirms Source #2 "
+        "(handle_anthropic_claude_code_tracing per-call child-span emit).\n"
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Two emit sources in `litellm/integrations/arize/_utils.py` were re-attaching the entire prior conversation history on every LLM span, producing **O(L²) trace storage growth** per session. This has cost ~\$5K in accumulated Arize storage.

This patch makes both sources **linear**.

## Sources fixed

**1. Parent span attribute bloat** (`set_attributes`)
Loop over all messages → emit only the last message as `llm.input_messages.{idx}.{role,content}`.

**2. Child span explosion** (`handle_anthropic_claude_code_tracing`)
Three loops walking the full message array → cap each at \`start_idx = max(0, len(messages) - 2)\` so only the latest turn produces \`Claude_Code_Internal_Prompt_*\`, \`_Internal_Tool_*\`, and \`Tool_<name>\` child spans.

Latest-turn detail (most recent tool call, last user message, response) is preserved. Prior turns are not re-emitted on every call — each turn lands in Phoenix exactly once on the call where it actually happened.

## Verification (synthetic, in-memory)

\`scripts/measure_l2_baseline.py\` simulates a Claude Code session by calling \`set_attributes\` L times with progressively longer message histories, captures emitted spans via an in-memory OTEL exporter, and prints a growth report.

| L=30 | child spans | input_msg attrs | child/L | child/L² |
|------|-------------|------------------|---------|---------|
| Before | 1455 | 1920 | 48.5 (growing) | 1.62 (→ const) |
| After  | 150  | 60   | 5.00 (constant) | 0.17 (→ 0)     |

`child/L` constant at 5.00 across L=[5,10,20,30] post-patch confirms linear emit. `child/L²` decaying as 1/L confirms quadratic is gone.

Reports captured at \`scripts/measure_l2_baseline.before.txt\` and \`.after.txt\`.

## Not yet done (follow-up)

- Docker image rebuild from this branch and tag
- End-to-end run inside Daytona \`dev-agent-lens\` sandbox: real Claude Code session → patched LiteLLM container → Phoenix → diff against baseline image to prove **content equivalence** in the deployed pipeline (not just synthetic).
- Once content equivalence is verified end-to-end, push image to \`main\` of \`aowen14/litellm-oauth-fix\`.

## Test plan

- [x] Synthetic harness shows linear emit (\`scripts/measure_l2_baseline.py\`)
- [ ] Docker image rebuilt from this branch
- [ ] Daytona sandbox end-to-end test on identical scripted scenario (baseline vs patched)
- [ ] Phoenix output diffed for content equivalence
- [ ] No regressions on existing LiteLLM tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)